### PR TITLE
Added options.config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ grunt.initConfig({
 grunt.registerTask('default', ['flow', 'watch']);
 ```
 
+#### options.config
+Type: `String`
+Default value: `.flowconfig`
+
+Path to the configuration file for flow.  Default is `.flowconfig` in the current directory.
+
 ### Usage
 
 #### Config
@@ -86,6 +92,8 @@ grunt.registerTask('default', ['flow', 'watch']);
 ```
 
 You can look up more information on the `.flowconfig` file on the flow [website](http://flowtype.org/docs/advanced-configuration.html#_)
+
+Note that you can set the path to configuration file with `options.config`.
 
 #### Task
 

--- a/tasks/flow.js
+++ b/tasks/flow.js
@@ -20,11 +20,12 @@ module.exports = function(grunt) {
         var options = this.options({
             testing: false,
             style: 'color',
-            server: false
+            server: false,
+            config: '.flowconfig'
         });
 
         // Read .flowconfig file
-        var flowConfigFile = grunt.file.read('.flowconfig');
+        var flowConfigFile = grunt.file.read(options.config);
 
         if (!flowConfigFile) {
             return grunt.error('No .flowconfig file found!');

--- a/tasks/flow.js
+++ b/tasks/flow.js
@@ -28,7 +28,7 @@ module.exports = function(grunt) {
         var flowConfigFile = grunt.file.read(options.config);
 
         if (!flowConfigFile) {
-            return grunt.error('No .flowconfig file found!');
+            return grunt.log.error('No .flowconfig file found!');
         }
 
         // Recreate color output from flow library


### PR DESCRIPTION
In my project, `.flowconfig` is not put in root of repo.  So I added `config` option to the task to customize the place of config file. Please note that this doesn't break any current behavior.
