### PR TITLE
Add procOpts to flow task for grunt

### DIFF
--- a/tasks/flow.js
+++ b/tasks/flow.js
@@ -23,6 +23,20 @@ module.exports = function(grunt) {
             server: false
         });
 
+        var procOpts = {
+        };
+        var procOptsPipe = {
+            stdio: ['pipe'],
+        };
+
+        var procOptsEnv = options.procOpts ? options.procOpts.env : undefined;
+        // could allow for additional process options, explicitly or by iteration...
+
+        if (procOptsEnv) {
+            procOpts.env = procOptsEnv;
+            procOptsPipe.env = procOptsEnv;
+        }
+
         // Read .flowconfig file
         var flowConfigFile = grunt.file.read('.flowconfig');
 
@@ -115,7 +129,7 @@ module.exports = function(grunt) {
 
         var done = this.async();
         // Run `flow check` command
-        var cmd = spawn(flow, options.server ? [] : ['check'], {stdio: ['pipe']});
+        var cmd = spawn(flow, options.server ? [] : ['check'], procOptsPipe);
 
         cmd.stdout.on('data', function(data) {
             // Convert data buffer to ascii string and colorize output
@@ -141,7 +155,7 @@ module.exports = function(grunt) {
         if (options.server === true) {
           // Catch CTRL+C  to kill the flow server
           process.on('SIGINT', function() {
-            var closeServerCmd = spawn(flow, ['stop']);
+            var closeServerCmd = spawn(flow, ['stop'], procOpts);
             closeServerCmd.stdout.on('data', function(data) {
                 var output = data.toString('ascii', 0, data.length);
                 console.log(output);
@@ -149,7 +163,7 @@ module.exports = function(grunt) {
 
             closeServerCmd.on('close', function() {
                 process.kill(0);
-            })
+            });
           }.bind(this));
         }
 


### PR DESCRIPTION
This allows the setting of the process options such as the environment when spawning flow, which is useful when running flow in particular environments such as build/CI.

Also fixed a semi-colon lint error.
