### PR TITLE
Make flow-bin a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-flow",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Validates JavaScript with Facebook's Flow Library",
   "homepage": "https://github.com/larsonjj/grunt-flow",
   "repository": "https://github.com/larsonjj/grunt-flow",
@@ -31,6 +31,9 @@
   },
   "scripts": {
     "test": "grunt test"
+  },
+  "peerDependencies": {
+    "flow-bin": ">0.1.1"
   },
   "dependencies": {
     "chalk": "^0.5.1",


### PR DESCRIPTION
This fixes issue #9 

Otherwise it's impossible to explicitly specify the `flow-bin` version that should be used. In my case it just installed 0.42 but I wanted 0.49.